### PR TITLE
Remove underscores from eventtype, map eqxml types to quakeml types

### DIFF
--- a/src/lib/classes/fdsn/QuakemlFeed.class.php
+++ b/src/lib/classes/fdsn/QuakemlFeed.class.php
@@ -114,6 +114,17 @@ class QuakemlFeed extends AbstractFeed {
     $type = $event['event_type'];
     if ($type === '') {
       $type = 'earthquake';
+    } else {
+      // remove underscores
+      $type = str_replace('_', ' ', $type);
+      // map EQXML types
+      if ($type === 'quarry') {
+        $type = 'quarry blast';
+      } else if ($type === 'nuke') {
+        $type = 'nuclear explosion';
+      } else if ($type === 'sonicboom') {
+        $type = 'sonic boom';
+      }
     }
     $entry .= $this->getElement('type', $type);
 

--- a/src/lib/classes/fdsn/QuakemlFeed.class.php
+++ b/src/lib/classes/fdsn/QuakemlFeed.class.php
@@ -122,6 +122,12 @@ class QuakemlFeed extends AbstractFeed {
         $type = 'quarry blast';
       } else if ($type === 'nuke') {
         $type = 'nuclear explosion';
+      } else if ($type === 'shot') {
+        $type = 'mining explosion';
+      } else if ($type === 'rockfall') {
+        $type = 'landslide';
+      } else if ($type === 'rockburst') {
+        $type = 'rock burst';
       } else if ($type === 'sonicboom') {
         $type = 'sonic boom';
       }


### PR DESCRIPTION
`quarry` and `sonicboom` were the only two currently in comcat, added `nuke` just in case.