### PR TITLE
Update detail query to consider deleted products (they are filtered b…

### DIFF
--- a/src/lib/classes/detail/geojson.inc.php
+++ b/src/lib/classes/detail/geojson.inc.php
@@ -2,7 +2,7 @@
 
 
 header('Content-type: application/json');
-if( $event == null ) {
+if ($event == null) {
   header('HTTP/1.0 404 Not Found');
   print '{"message": "Event not found."}';
   return;

--- a/src/lib/classes/detail/geojsonp.inc.php
+++ b/src/lib/classes/detail/geojsonp.inc.php
@@ -2,7 +2,7 @@
 
 
 header('Content-type: text/javascript');
-if($event == null ) {
+if ($event == null) {
   header('HTTP/1.0 404 Not Found');
   print 'eqfeed_callback({"message": "Event not found."})';
   return;
@@ -11,7 +11,8 @@ if($event == null ) {
 global $storage;
 
 
-$event_array = $event->toArray($storage);
+$event_array = $event->toArray($storage, $query->includedeleted,
+    $query->includesuperseded);
 
 // add event summary for region, and other summarized properties
 // this is hacky and slow, but effective

--- a/src/lib/classes/detail/quakeml.inc.php
+++ b/src/lib/classes/detail/quakeml.inc.php
@@ -89,6 +89,31 @@ echo '<eventParameters publicID="quakeml:earthquake.usgs.gov/eventParameters/' .
 
 echo '<event catalog:datasource="anss" catalog:eventsource="' . $source . '" catalog:eventid="' . $sourceCode . '" publicID="quakeml:earthquake.usgs.gov/event/' . $fullid . '">';
 
+  // event type
+  $type = $event['event_type'];
+  if ($event['eventStatus'] === 'DELETE') {
+    $type = 'not existing';
+  } else if ($type === null || $type === '') {
+    $type = 'earthquake';
+  } else {
+    // remove underscores
+    $type = str_replace('_', ' ', $type);
+    // map EQXML types
+    if ($type === 'quarry') {
+      $type = 'quarry blast';
+    } else if ($type === 'nuke') {
+      $type = 'nuclear explosion';
+    } else if ($type === 'shot') {
+      $type = 'mining explosion';
+    } else if ($type === 'rockfall') {
+      $type = 'landslide';
+    } else if ($type === 'rockburst') {
+      $type = 'rock burst';
+    } else if ($type === 'sonicboom') {
+      $type = 'sonic boom';
+    }
+  }
+  echo '<type>' . $type . '</type>';
 
   // output each origin product
   foreach ($origins as $origin) {

--- a/src/lib/classes/fdsn/FDSNEventWebService.class.php
+++ b/src/lib/classes/fdsn/FDSNEventWebService.class.php
@@ -128,14 +128,13 @@ class FDSNEventWebService {
     global $APP_DIR;
     global $index;
 
-    // current versions, not deleted
-    $resultType = ProductIndexQuery::RESULT_TYPE_CURRENT;
+    // current versions, including deleted products
+    // need deleted products, so we can tell whether event deleted
+    // they are filtered out of results later.
+    $resultType = ProductIndexQuery::RESULT_TYPE_CURRENT_WITH_DELETE;
     if ($query->includesuperseded) {
       // all products
       $resultType = ProductIndexQuery::RESULT_TYPE_ALL;
-    } else if ($query->includedeleted) {
-      // current versions, including deleted products
-      $resultType = ProductIndexQuery::RESULT_TYPE_CURRENT_WITH_DELETE;
     }
 
     // use ProductIndex for detail

--- a/src/lib/classes/fdsn/QuakemlFeed.class.php
+++ b/src/lib/classes/fdsn/QuakemlFeed.class.php
@@ -112,7 +112,9 @@ class QuakemlFeed extends AbstractFeed {
 
     // event type
     $type = $event['event_type'];
-    if ($type === null || $type === '') {
+    if ($event['eventStatus'] === 'DELETE') {
+      $type = 'not existing';
+    } else if ($type === null || $type === '') {
       $type = 'earthquake';
     } else {
       // remove underscores


### PR DESCRIPTION
…y geojson later)

This corrects detail geojson feeds to correctly respond with 409 conflict.
Other detail formats need to be checked to ensure they work as expected (kml, etc); should these still display a marker but say deleted?