### PR TITLE
Update getErrors to be public

### DIFF
--- a/src/htdocs/js/fdsn/FDSNModelValidator.js
+++ b/src/htdocs/js/fdsn/FDSNModelValidator.js
@@ -122,7 +122,6 @@ var FDSNModelValidator = function (options) {
       _this,
 
       _getErrorFields,
-      _getErrors,
       _initialize,
       _onModelChange;
 
@@ -137,12 +136,11 @@ var FDSNModelValidator = function (options) {
   };
 
   /**
-   * @return {Object}
-   *      An object hash of {fieldName: errorMessage} for current errors on
-   *      _this._model.
+   * Event handler when _this._model changes. Auto-validates the model new model
+   *
    */
-  _getErrors = function () {
-    return _errors;
+  _onModelChange = function () {
+    _errors = _validate(_model.getNonEmpty());
   };
 
   /**
@@ -162,6 +160,15 @@ var FDSNModelValidator = function (options) {
   };
 
   /**
+   * @return {Object}
+   *      An object hash of {fieldName: errorMessage} for current errors on
+   *      _this._model.
+   */
+  _this.getErrors = function () {
+    return _errors;
+  };
+
+  /**
    * @return {Boolean}
    *      True if the combination of field values in _this._model currently
    *      valid, false otherwise.
@@ -175,14 +182,6 @@ var FDSNModelValidator = function (options) {
     }
 
     return true;
-  };
-
-  /**
-   * Event handler when _this._model changes. Auto-validates the model new model
-   *
-   */
-  _onModelChange = function () {
-    _errors = _validate(_model.getNonEmpty());
   };
 
   _initialize();


### PR DESCRIPTION
getErrors was a private method. This meant that no errors were being displayed on the search form, and the form was still being submitted.  

To see what is happening, perform a radial search on a lat/lon without specifying a radius.

http://earthquake.usgs.gov/fdsnws/event/1/query?starttime=2015-06-02+00%3A00%3A00&endtime=2015-06-09+23%3A59%3A59&minmagnitude=6&maxmagnitude=&mindepth=&maxdepth=&maxlatitude=&minlongitude=&maxlongitude=&minlatitude=&latitude=35&longitude=35&minradiuskm=&maxradiuskm=&mingap=&maxgap=&reviewstatus=&minsig=&maxsig=&alertlevel=&minmmi=&maxmmi=&mincdi=&maxcdi=&minfelt=&catalog=&contributor=&producttype=&format=maplist&kmlcolorby=age&callback=&orderby=time&limit=&offset=

The same problem exists when returning to the form from the map, when the form tries to validate a valid radial search. 