### PR TITLE
Only showing event product types that are not deleted

### DIFF
--- a/src/lib/sql/fdsnws/getEventProductTypes.sql
+++ b/src/lib/sql/fdsnws/getEventProductTypes.sql
@@ -13,7 +13,8 @@ BEGIN
   DECLARE cur_products CURSOR FOR
     SELECT type
     FROM preferredProduct
-    WHERE eventid = in_eventid;
+    WHERE eventid = in_eventid
+    AND status <> 'DELETE';
   DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;
 
   SET out_producttypes = NULL;


### PR DESCRIPTION
fixes #5 

Style attempting to test locally,  but per discussion,  I'm pushing this up,  on the theory that since getEventProductSources was already working,  an identical change in getEventProductTypes should work as well.   And per discussion,  no changes were made in getEventIds,  so the users could still find deleted ids if that's what they really want. 