### PR TITLE
Csv backward compatibility

### DIFF
--- a/src/htdocs/csv.php
+++ b/src/htdocs/csv.php
@@ -38,25 +38,25 @@ if (!isset($TEMPLATE)) {
       <li><a href="glossary.php#time">time</a></li>
       <li><a href="glossary.php#latitude">latitude</a></li>
       <li><a href="glossary.php#longitude">longitude</a></li>
-      <li><a href="glossary.php#horizontalError">horizontalError</a></li>
       <li><a href="glossary.php#depth">depth</a></li>
-      <li><a href="glossary.php#depthError">depthError</a></li>
       <li><a href="glossary.php#mag">mag</a></li>
       <li><a href="glossary.php#magType">magType</a></li>
-      <li><a href="glossary.php#magError">magError</a></li>
-      <li><a href="glossary.php#magNst">magNst</a></li>
       <li><a href="glossary.php#nst">nst</a></li>
       <li><a href="glossary.php#gap">gap</a></li>
       <li><a href="glossary.php#dmin">dmin</a></li>
       <li><a href="glossary.php#rms">rms</a></li>
-      <li><a href="glossary.php#type">type</a></li>
-      <li><a href="glossary.php#status">status</a></li>
       <li><a href="glossary.php#net">net</a></li>
       <li><a href="glossary.php#id">id</a></li>
-      <li><a href="glossary.php#locationSource">locationSource</a></li>
-      <li><a href="glossary.php#magSource">magSource</a></li>
       <li><a href="glossary.php#updated">updated</a></li>
       <li><a href="glossary.php#place">place</a></li>
+      <li><a href="glossary.php#type">type</a></li>
+      <li><a href="glossary.php#locationSource">locationSource</a></li>
+      <li><a href="glossary.php#magSource">magSource</a></li>
+      <li><a href="glossary.php#horizontalError">horizontalError</a></li>
+      <li><a href="glossary.php#depthError">depthError</a></li>
+      <li><a href="glossary.php#magError">magError</a></li>
+      <li><a href="glossary.php#magNst">magNst</a></li>
+      <li><a href="glossary.php#status">status</a></li>
     </ul>
 
     <p>

--- a/src/htdocs/glossary.php
+++ b/src/htdocs/glossary.php
@@ -408,8 +408,8 @@ if (!isset($TEMPLATE)) {
           <dt>Data Type</dt><dd class="datatype">Integer</dd>
           <dt>Description</dt>
           <dd>
-            The total number of seismic stations which reported
-            P- and S-arrival times for this earthquake.
+            The total number of seismic stations used to determine earthquake
+            location.
           </dd>
         </dl>
       </dd>

--- a/src/lib/classes/fdsn/CSVFeed.class.php
+++ b/src/lib/classes/fdsn/CSVFeed.class.php
@@ -11,25 +11,25 @@ class CSVFeed extends AbstractFeed {
       'time',
       'latitude',
       'longitude',
-      'horizontalError',
       'depth',
-      'depthError',
       'mag',
       'magType',
-      'magError',
-      'magNst',
       'nst',
       'gap',
       'dmin',
       'rms',
-      'type',
-      'status',
       'net',
       'id',
-      'locationSource',
-      'magSource',
       'updated',
-      'place'
+      'place',
+      'type',
+      'horizontalError',
+      'depthError',
+      'magError',
+      'magNst',
+      'status',
+      'locationSource',
+      'magSource'
     )) . "\n";
   }
 
@@ -40,29 +40,29 @@ class CSVFeed extends AbstractFeed {
       $this->formatter->formatDateIso($event['eventTime']),
       $event['eventLatitude'],
       $event['eventLongitude'],
-      $event['horizontal_error'],
       $event['eventDepth'],
-      $event['vertical_error'],
       $event['eventMagnitude'],
       $event['magnitude_type'],
-      $event['magnitude_error'],
-      $event['magnitude_num_stations_used'],
       $event['num_stations_used'],
       $event['azimuthal_gap'],
       $event['minimum_distance'],
       $event['standard_error'],
-      $event['event_type'],
-      strtolower($event['review_status']),
       $event['eventSource'],
       $event['eventSource'] . $event['eventSourceCode'],
+      $this->formatter->formatDateIso($event['eventUpdateTime']),
+      '"' . str_replace('"', '""', $event['region']) . '"',
+      $event['event_type'],
+      $event['horizontal_error'],
+      $event['vertical_error'],
+      $event['magnitude_error'],
+      $event['magnitude_num_stations_used'],
+      strtolower($event['review_status']),
       $event['origin_source']
           ? strtolower($event['origin_source'])
           : $event['eventSource'],
       $event['magnitude_source']
           ? strtolower($event['magnitude_source'])
-          : $event['eventSource'],
-      $this->formatter->formatDateIso($event['eventUpdateTime']),
-      '"' . str_replace('"', '""', $event['region']) . '"'
+          : $event['eventSource']
     )) . "\n";
   }
 


### PR DESCRIPTION
Move new columns to end for fragile csv parsers that depend on column order (rather than column header).

Also fixes usgs/earthquake-event-ws#110 .