### PR TITLE
Add "T" date time separator to text format (as specified)

### DIFF
--- a/src/lib/classes/fdsn/TextFeed.class.php
+++ b/src/lib/classes/fdsn/TextFeed.class.php
@@ -21,7 +21,7 @@ class TextFeed extends AbstractFeed {
 
     return implode('|', array(
       $event['eventSource'] . $event['eventSourceCode'],
-      $this->formatter->formatDateIso($event['eventTime'], null, '', ' '),
+      $this->formatter->formatDateIso($event['eventTime'], null, ''),
       $event['eventLatitude'],
       $event['eventLongitude'],
       $event['eventDepth'],


### PR DESCRIPTION
FDSN spec now calls for "T" as date time separator in text format.