### PR TITLE
Return null when an empty string is passed into the date/time formatter

### DIFF
--- a/src/htdocs/js/fdsn/FDSNFormatter.js
+++ b/src/htdocs/js/fdsn/FDSNFormatter.js
@@ -47,6 +47,10 @@ var formatDateTimeFromString = function (stamp) {
       parts,
       ymd;
 
+  if (stamp === '') {
+    return null;
+  }
+
   parts = stamp.split(/( |T)/);
   ymd = parts[0] || '';
   hms = parts[1] || '';


### PR DESCRIPTION
fixes #166 