### PR TITLE
Update geojson details feed to display the title with "Scenario" like is done in the summary feed

### DIFF
--- a/src/lib/classes/pdl/EventSummary.class.php
+++ b/src/lib/classes/pdl/EventSummary.class.php
@@ -27,7 +27,9 @@ class EventSummary {
   public $lastModified = null;
 
 
-  public function __construct() {}
+  public function __construct() {
+    $this->formatter = new Formatter();
+  }
 
   public function getEventIndexId() { return $this->eventIndexId; }
   public function setEventIndexId($indexId) { $this->eventIndexId = $indexId; }
@@ -157,7 +159,7 @@ class EventSummary {
     $type = $this->getEventType();
     if($type == null || strtolower($type) == 'earthquake') {
       // assume earthquake
-      $type = '';
+      $type = 'Earthquake';
     } else {
       $temp = strtolower($type);
       if     ($temp == "quarry")    $type = "Quarry Blast";
@@ -180,7 +182,15 @@ class EventSummary {
   }
 
   public function getTitle() {
-    return 'M' . $this->getHumanMagnitude() . ' ' . $this->getHumanEventType() . ' - ' . $this->getRegion();
-  }
+    $eventtype = $this->getHumanEventType();
 
+    if ($eventtype === 'origin-scenario') {
+      $eventtype = 'Scenario ' . $eventtype;
+    }
+
+    return
+        $this->formatter->formatMagnitude($this->getMagnitude()) .
+        ($eventtype !== 'Earthquake' ? ' ' . $eventtype : '') .
+        ' - ' . $this->getRegion();
+  }
 }


### PR DESCRIPTION
fixes #156 

This doesn't really fix the issue. I'm not sure why the `event-type = "origin-scenario"` on the summary feed, while `event-type = "earthquake"` in the details feed?

Basically, this change handles the titles in the same way, but it will never actually display "Scenario"