### PR TITLE
Allow OPTIONS in apache config

### DIFF
--- a/src/conf/config.inc.php
+++ b/src/conf/config.inc.php
@@ -1,4 +1,11 @@
 <?php
+
+if (isset($_SERVER['REQUEST_METHOD']) &&
+    $_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+  // short-circuit OPTIONS method requests, which are CORS related
+  exit();
+}
+
 // use UTC timezone for date parsing/formatting
 date_default_timezone_set("UTC");
 

--- a/src/lib/pre-install.php
+++ b/src/lib/pre-install.php
@@ -103,8 +103,8 @@ Alias ' . $storage_url . ' ' . $storage_directory . '
     php_flag engine off
   </IfModule>
 
-  # only allow GET access
-  <LimitExcept GET>
+  # only allow GET access (and OPTIONS for CORS)
+  <LimitExcept GET OPTIONS>
     Order allow,deny
     Deny from all
   </LimitExcept>
@@ -120,16 +120,16 @@ Alias ' . $storage_url . ' ' . $storage_directory . '
   ExpiresActive on
   ExpiresDefault "access plus 1 days"
 
-  # only allow GET access
-  <LimitExcept GET>
+  # only allow GET access (and OPTIONS for CORS)
+  <LimitExcept GET OPTIONS>
     Order allow,deny
     Deny from all
   </LimitExcept>
 </Location>
 
 <Location ' . $FDSN_PATH . '/>
-  # only allow GET access
-  <LimitExcept GET>
+  # only allow GET access (and OPTIONS for CORS)
+  <LimitExcept GET OPTIONS>
     Order allow,deny
     Deny from all
   </LimitExcept>


### PR DESCRIPTION
This is the start of OPTIONS support, but additional support is likely needed to not actually return database content or similar from php.  Possibly detect and handle OPTIONS requests in config.inc.php?