### PR TITLE
Increase summary limit

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthquake-event-ws",
-  "version": "1.5.8",
+  "version": "1.5.9",
   "description": "Web service for querying ComCat.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthquake-event-ws",
-  "version": "1.5.9",
+  "version": "1.6.2",
   "description": "Web service for querying ComCat.",
   "repository": {
     "type": "git",

--- a/src/htdocs/summary.php
+++ b/src/htdocs/summary.php
@@ -194,6 +194,8 @@ if ($networkLink) {
 
 // serve summary feed
 $service = new FDSNEventWebService($fdsnIndex);
+// increase limit for summary feeds
+$service->serviceLimit = 30000;
 try {
   $service->handleSummaryQuery($query);
 } catch (Exception $e) {


### PR DESCRIPTION
the current hawaii sequence has caused the all_month feed to contain ~21k events.