### PR TITLE
Fdsnws summary updates

### DIFF
--- a/src/lib/sql/fdsnws/getEventIds.sql
+++ b/src/lib/sql/fdsnws/getEventIds.sql
@@ -13,7 +13,7 @@ BEGIN
   DECLARE done INT DEFAULT 0;
   DECLARE cur_ids CURSOR FOR
     SELECT DISTINCT eventSource, eventSourceCode
-    FROM productSummary
+    FROM currentProducts
     WHERE eventid = in_eventid
       AND eventSource IS NOT NULL
       AND eventSourceCode IS NOT NULL;

--- a/src/lib/sql/fdsnws/getEventProductTypes.sql
+++ b/src/lib/sql/fdsnws/getEventProductTypes.sql
@@ -11,9 +11,10 @@ BEGIN
 
   DECLARE done INT DEFAULT 0;
   DECLARE cur_products CURSOR FOR
-    SELECT type
-    FROM preferredProduct
-    WHERE eventid = in_eventid;
+    SELECT DISTINCT type
+    FROM currentProducts
+    WHERE eventid = in_eventid
+    AND status <> 'DELETE';
   DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;
 
   SET out_producttypes = NULL;


### PR DESCRIPTION
In rare cases when a product is updated to associate to a different event, current behavior results in the old event id being listed in the `ids` list of a different event.  This is misleading at best.

This pull request makes `getEventIds` and `getEventProductTypes` more consistent with `getEventProductSources`:
https://github.com/jmfee-usgs/earthquake-event-ws/blob/839be42dc153e2593b6dc77e3ec1f3a5027f2829/src/lib/sql/fdsnws/getEventProductSources.sql#L17

The primary downside (or upside depending on who you ask) to these changes is for **deleted** events that may no longer be listed in the `ids` list;  when corresponding delete products do not include an event id.