### PR TITLE
Update to 1 minute caching as requested by llastowka

### DIFF
--- a/src/htdocs/fdsn.php
+++ b/src/htdocs/fdsn.php
@@ -10,8 +10,9 @@ if (!isset($TEMPLATE)) {
     include_once '../conf/feeds.inc.php';
 
     // caching headers
-    $CACHE_MAXAGE = 900;
-    include_once '../lib/cache.inc.php';
+    // per llastowka: cache for 60 seconds regardless of age
+    $CACHE_MAXAGE = 60;
+    include $APP_DIR . '/lib/cache.inc.php';
 
     $service = new FDSNEventWebService($fdsnIndex);
     $usage = false;

--- a/src/htdocs/inc/terms.inc.php
+++ b/src/htdocs/inc/terms.inc.php
@@ -2,28 +2,28 @@
   $dateRanges = array(
     "hour" => array (
       "name" => "Past Hour",
-      "help" => "Updated every 5 minutes.",
+      "help" => "Updated every minute.",
       "url" => "hour",
       'mags' => array('significant', '2.5', '1', 'all')
     ),
 
     "day" => array (
       "name" => "Past Day",
-      "help" => "Updated every 5 minutes.",
+      "help" => "Updated every minute.",
       "url" => "day",
       'mags' => array('significant', '2.5', '1', 'all') // Hmm?
     ),
 
     "week" => array (
       "name" => "Past 7 Days",
-      "help" => "Updated every 5 minutes.",
+      "help" => "Updated every minute.",
       "url" => "week",
       'mags' => array('significant', '4.5', '2.5', 'all') // Hmm?
     ),
 
     "month" => array (
       "name" => "Past 30 Days",
-      "help" => "Updated every 15 minutes.",
+      "help" => "Updated every minute.",
       "url" => "month",
       'mags' => array('significant', '4.5', '2.5', 'all') // Hmm?
     )
@@ -44,7 +44,7 @@
     ),
 
     "month" => array (
-      "help" => "Updated every 15 minutes."
+      "help" => "Updated every minute."
     )
   );
 

--- a/src/htdocs/summary.php
+++ b/src/htdocs/summary.php
@@ -101,18 +101,8 @@ try {
 
 
 // caching headers
-  // default to 5 minutes
-  $CACHE_MAXAGE = 300;
-  if ($size === 'significant') {
-    // all significant feeds are 1 minute
-    $CACHE_MAXAGE = 60;
-  } else if ($age === 'month') {
-    // all other one month feeds are 15 minutes
-    $CACHE_MAXAGE = 900;
-  } else if ($query->format === 'geojson') {
-    // geojson offers lower default expiration
-    $CACHE_MAXAGE = 60;
-  }
+  // per llastowka: cache for 60 seconds regardless of age
+  $CACHE_MAXAGE = 60;
   include $APP_DIR . '/lib/cache.inc.php';
 
 


### PR DESCRIPTION
As requested by @llastowka-usgs : only cache summary feeds for one minute.