### PR TITLE
Product summary event status

### DIFF
--- a/src/lib/sql/fdsnws/_config.inc.php
+++ b/src/lib/sql/fdsnws/_config.inc.php
@@ -17,6 +17,7 @@ $files = array(
   'getEventProductTypes.sql',
   'getEventIds.sql',
   'getEventSummary.sql',
+  'productSummaryEventStatus.sql',
   'updateEventSummary.sql',
   'recreateEventSummary.sql',
   'summary_sql.php',

--- a/src/lib/sql/fdsnws/on_event_update_trigger.sql
+++ b/src/lib/sql/fdsnws/on_event_update_trigger.sql
@@ -1,8 +1,12 @@
+-- potentially repetitive, but does not hurt
+DROP TRIGGER IF EXISTS on_event_update_trigger;
+
 delimiter //
 CREATE TRIGGER on_event_update_trigger AFTER UPDATE ON event FOR EACH ROW
 BEGIN
   CALL updateEventSummary(NEW.id);
   CALL summarizeEventProducts(NEW.id);
+  CALL updateProductSummaryEventStatus(NEW.id);
 END;
 //
 delimiter ;

--- a/src/lib/sql/fdsnws/productSummaryEventStatus.sql
+++ b/src/lib/sql/fdsnws/productSummaryEventStatus.sql
@@ -1,0 +1,100 @@
+CREATE TABLE IF NOT EXISTS productSummaryEventStatus (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  eventId BIGINT NOT NULL,
+  eventUpdated BIGINT NOT NULL,
+  productSummaryId BIGINT NOT NULL,
+  eventPreferred INT DEFAULT 0,
+
+  KEY preferredEventProductIndex (eventId, eventPreferred),
+  FOREIGN KEY (eventId) REFERENCES event(id) ON DELETE CASCADE,
+  FOREIGN KEY (productSummaryId) REFERENCES productSummary(id) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+delimiter //
+DROP PROCEDURE IF EXISTS updateProductSummaryEventStatus //
+CREATE PROCEDURE updateProductSummaryEventStatus(IN in_eventid INT)
+  MODIFIES SQL DATA
+BEGIN
+  DECLARE preferredId INT;
+
+  -- run in a transaction
+  START TRANSACTION;
+
+  -- remove existing summary status
+  DELETE FROM productSummaryEventStatus WHERE eventId = in_eventid;
+
+  -- add catalog preferred origin products
+  INSERT INTO productSummaryEventStatus
+    (eventId, eventUpdated, productSummaryId, eventPreferred)
+    SELECT
+      e.id as eventId,
+      e.updated as eventUpdated,
+      ps.id as productSummaryId,
+      0 as eventPreferred
+    FROM event e
+    JOIN preferredProduct ps ON (ps.eventid = e.id)
+    WHERE e.id = in_eventid
+    AND ps.type in ('origin', 'origin-scenario');
+
+  -- find preferred origin
+  SELECT id into preferredId FROM productSummary
+  WHERE eventid = in_eventid
+  AND id IN (
+    SELECT productSummaryId
+    FROM productSummaryEventStatus
+    WHERE eventId = in_eventid
+  )
+  ORDER BY preferred DESC, updateTime DESC
+  LIMIT 1;
+
+  -- set preferred origin
+  UPDATE productSummaryEventStatus
+  SET eventPreferred = 1
+  WHERE eventId = in_eventid
+  AND productSummaryId = preferredId;
+
+  -- done
+  COMMIT;
+
+END;
+//
+delimiter ;
+
+
+delimiter //
+DROP PROCEDURE IF EXISTS summarizeProductSummaryEventStatus //
+CREATE PROCEDURE summarizeProductSummaryEventStatus()
+  MODIFIES SQL DATA
+BEGIN
+  DECLARE eventid INT;
+
+  DECLARE done INT DEFAULT 0;
+  DECLARE cur_events CURSOR FOR
+    SELECT DISTINCT e.id
+    FROM event e
+    JOIN preferredProduct ps ON (ps.eventid = e.id)
+    LEFT JOIN productSummaryEventStatus pses ON (pses.eventId = e.id)
+    WHERE ps.type in ('origin', 'origin-scenario')
+    AND (
+      pses.eventUpdated IS NULL
+      OR pses.eventUpdated < e.updated
+    )
+    LIMIT 100000;
+
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = 1;
+  -- loop over all events, updating eventSummary table
+  OPEN cur_events;
+  cur_events_loop: LOOP
+    FETCH cur_events INTO eventid;
+    IF done = 1 THEN
+      CLOSE cur_events;
+      LEAVE cur_events_loop;
+    END IF;
+
+    CALL updateProductSummaryEventStatus(eventid);
+  END LOOP cur_events_loop;
+
+  COMMIT;
+END;
+//
+delimiter ;

--- a/src/lib/sql/fdsnws/productSummaryEventStatus.sql
+++ b/src/lib/sql/fdsnws/productSummaryEventStatus.sql
@@ -17,9 +17,6 @@ CREATE PROCEDURE updateProductSummaryEventStatus(IN in_eventid INT)
 BEGIN
   DECLARE preferredId INT;
 
-  -- run in a transaction
-  START TRANSACTION;
-
   -- remove existing summary status
   DELETE FROM productSummaryEventStatus WHERE eventId = in_eventid;
 
@@ -52,10 +49,6 @@ BEGIN
   SET eventPreferred = 1
   WHERE eventId = in_eventid
   AND productSummaryId = preferredId;
-
-  -- done
-  COMMIT;
-
 END;
 //
 delimiter ;
@@ -91,7 +84,11 @@ BEGIN
       LEAVE cur_events_loop;
     END IF;
 
+    -- run in a transaction
+    START TRANSACTION;
     CALL updateProductSummaryEventStatus(eventid);
+    COMMIT;
+
   END LOOP cur_events_loop;
 
   COMMIT;


### PR DESCRIPTION
In the on event update trigger, summarize preferred origin products in a new indexed table.  
Update FDSNIndex to use new table when possible, eliminating most "not exists" subqueries.

Deployment steps:
- run the `productSummaryEventStatus.sql` script to create the table and procedures, 
- then run `on_event_update_trigger.sql` to call the new procedure when events are updated.

- then repeatedly `CALL summarizeProductSummaryEventStatus()` until all events are done.
  currently updates the next 100k events in about 10 minutes, this shouldn't block other queries (but should also verify).

- once table is populated, deploy the updated `FDSNIndex.class.php`
