### PR TITLE
filter deleted origins when searching currentProducts

### DIFF
--- a/src/lib/sql/fdsnws/productSummaryEventStatus.sql
+++ b/src/lib/sql/fdsnws/productSummaryEventStatus.sql
@@ -32,18 +32,18 @@ BEGIN
     FROM event e
     JOIN currentProducts ps ON (ps.eventid = e.id)
     WHERE e.id = in_eventid
-    AND upper(ps.status) <> 'DELETE'
     AND ps.type in ('origin', 'origin-scenario');
 
   -- find preferred origin
-  SELECT id into preferredId FROM productSummary
-  WHERE eventid = in_eventid
-  AND id IN (
+  SELECT id into preferredId FROM productSummary ps
+  WHERE ps.eventid = in_eventid
+  AND upper(ps.status) <> 'DELETE'
+  AND ps.id IN (
     SELECT productSummaryId
     FROM productSummaryEventStatus
     WHERE eventId = in_eventid
   )
-  ORDER BY preferred DESC, updateTime DESC
+  ORDER BY ps.preferred DESC, ps.updateTime DESC
   LIMIT 1;
 
   -- set preferred origin

--- a/src/lib/sql/fdsnws/productSummaryEventStatus.sql
+++ b/src/lib/sql/fdsnws/productSummaryEventStatus.sql
@@ -32,6 +32,7 @@ BEGIN
     FROM event e
     JOIN currentProducts ps ON (ps.eventid = e.id)
     WHERE e.id = in_eventid
+    AND upper(ps.status) <> 'DELETE'
     AND ps.type in ('origin', 'origin-scenario');
 
   -- find preferred origin


### PR DESCRIPTION
Example event:

pr2020007012  - origin deleted, but currently flagged as preferred in summary feed

https://earthquake.usgs.gov/fdsnws/event/1/query?endtime=2020-01-07T13:00:23.024Z&format=geojson&latitude=17.97270&limit=20000&longitude=-66.66780&maxdepth=1000.000&maxradius=0.09876&mindepth=0.000&starttime=2020-01-07T13:00:22.024Z

us70006vq3 - correctly chosen as preferred in detail feed

https://earthquake.usgs.gov/fdsnws/event/1/query?eventid=pr2020007012&format=geojson