### PR TITLE
Deleted event details

### DIFF
--- a/src/htdocs/fdsn.php
+++ b/src/htdocs/fdsn.php
@@ -590,10 +590,11 @@ if (!isset($TEMPLATE)) {
       </tr>
       <tr id="includedeleted">
         <td><code>includedeleted</code></td>
-        <td>Boolean</td>
+        <td>Boolean, or "only"</td>
         <td>false</td>
         <td>
           Specify if deleted products and events should be included.
+          The value <code>only</code> returns only deleted events.
 
           <p>
           <small>

--- a/src/lib/classes/fdsn/FDSNEventWebService.class.php
+++ b/src/lib/classes/fdsn/FDSNEventWebService.class.php
@@ -23,7 +23,7 @@ class FDSNEventWebService extends WebService {
    */
   public function __construct($index, $redirect=false,
       $redirectMaxEventAge=self::DEFAULT_REDIRECT_MAX_EVENT_AGE) {
-    
+
     parent::__construct($index);
 
     global $CONFIG;
@@ -428,7 +428,12 @@ class FDSNEventWebService extends WebService {
       } else if ($name ==='nodata') {
         $query->nodata = $this->validateEnumerated($name, $value, array(204, 404));
       } else if ($name === 'includedeleted') {
-        $query->includedeleted = $this->validateBoolean($name, $value);
+        if ($value === 'only') {
+          $query->includedeleted = true;
+          $query->eventstatus = 'DELETE';
+        } else {
+          $query->includedeleted = $this->validateBoolean($name, $value);
+        }
       } else if ($name === 'includesuperseded') {
         $query->includesuperseded = $this->validateBoolean($name, $value);
       } else if ($name ==='jsonerror') {

--- a/src/lib/classes/fdsn/FDSNIndex.class.php
+++ b/src/lib/classes/fdsn/FDSNIndex.class.php
@@ -159,6 +159,24 @@ class FDSNIndex {
         $row['event_type'] = str_replace('_',' ', $row['event_type']);
         $event = utf8_encode_array($row);
 
+        if (
+          $event['eventStatus'] === 'DELETE'
+          && (
+            !$event['eventLatitude']
+            || !$event['eventLongitude']
+            || !$event['eventTime']
+          )
+        ) {
+          // deleted origins usually do not include details,
+          // use "preferred" event attributes for context
+          $event['eventLatitude'] = $event['preferredLatitude'];
+          $event['eventLongitude'] = $event['preferredLongitude'];
+          $event['eventTime'] = $event['preferredEventTime'];
+          // and these don't hurt
+          $event['eventDepth'] = $event['preferredDepth'];
+          $event['eventMagnitude'] = $event['preferredMagnitude'];
+        }
+
         if ($objects) {
           $event = new EventSummary();
           $event->eventIndexId = $row['eventid'];

--- a/src/lib/classes/fdsn/FDSNIndex.class.php
+++ b/src/lib/classes/fdsn/FDSNIndex.class.php
@@ -529,6 +529,11 @@ class FDSNIndex {
         $where[] = "( " . implode(" OR ", $types) . " )";
       }
 
+      if ($query->eventstatus !== null) {
+        $where[] = "upper(e.status) = upper(?)";
+        $params[] = $query->eventstatus;
+      }
+
       if ($query->reviewstatus !== null) {
         if ($query->reviewstatus == 'automatic') {
           $where[] = "(upper(os.review_status) = upper(?) OR os.review_status='')";

--- a/src/lib/classes/fdsn/FDSNQuery.class.php
+++ b/src/lib/classes/fdsn/FDSNQuery.class.php
@@ -76,6 +76,8 @@ class FDSNQuery {
 
   public $includedeleted = false;
   public $includesuperseded = false;
+  // event status for includedeleted=only
+  public $eventstatus = null;
 
   // formatting parameters
 


### PR DESCRIPTION
- use preferred event details when event is deleted and missing lat, lon, or time

  origin deletes typically do not include event details.

- add `includedeleted=only` api option to match only deleted events