### PR TITLE
Update version preparing for release tag

### DIFF
--- a/code.json
+++ b/code.json
@@ -3,7 +3,7 @@
     "name": "earthquake-event-ws",
     "organization": "U.S. Geological Survey",
     "description": "Web service for querying ComCat.",
-    "version": "v1.9.1",
+    "version": "v1.10.0",
     "status": "Production",
     "permissions": {
       "usageType": "openSource",

--- a/code.json
+++ b/code.json
@@ -28,7 +28,7 @@
       "email": "jmfee@usgs.gov"
     },
     "date": {
-      "metadataLastUpdated": "2020-05-11"
+      "metadataLastUpdated": "2020-05-29"
     }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "earthquake-event-ws",
-  "version": "1.9.1",
+  "version": "1.10.0",
   "description": "Web service for querying ComCat.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump minor version number (to 1.10.0)

- added `includedeleted=only` option to only search deleted events
- use event summary information when handling deleted events, since deleted. products omit summary information
- add `ew` to known catalogs and contributors lists on search page.
- new container build for local dev
- new product service
  some features need extent summary table and extent listener added to pdl configuration, but these are new features that are unused.


